### PR TITLE
perf: implement bulk job creation and enqueueing in ingestion route

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -66,11 +66,15 @@ async def ingest(file: UploadFile) -> IngestResponse:
         job_ids: list[str] = []
 
         try:
+            jobs_to_create = []
             for sp in split_paths:
                 sp_job_id = str(uuid.uuid4())
-                await jobs.create_job(job_id=sp_job_id, file_url=sp)
-                await queue.enqueue_job(job_id=sp_job_id, file_path=sp)
+                jobs_to_create.append({"job_id": sp_job_id, "file_url": str(sp), "file_path": str(sp)})
                 job_ids.append(sp_job_id)
+
+            if jobs_to_create:
+                await jobs.create_jobs_bulk(jobs_to_create)
+                await queue.enqueue_jobs_bulk(jobs_to_create)
         except Exception as exc:
             logger.exception("step=ingest enqueue_failed count=%s", len(job_ids))
             for jid in job_ids:

--- a/src/infrastructure/redis_queue.py
+++ b/src/infrastructure/redis_queue.py
@@ -71,6 +71,18 @@ class RedisQueue:
         message_id = await self._client.xadd(self._stream_key, {"payload": json.dumps(payload)})
         return str(message_id)
 
+    async def enqueue_jobs_bulk(self, jobs_data: list[dict[str, Any]]) -> list[str]:
+        if not jobs_data:
+            return []
+
+        async with self._client.pipeline(transaction=False) as pipe:
+            for job in jobs_data:
+                payload = {"job_id": job["job_id"], "file_path": job["file_path"]}
+                pipe.xadd(self._stream_key, {"payload": json.dumps(payload)})
+            message_ids = await pipe.execute()
+
+        return [str(mid) for mid in message_ids]
+
     async def read_one(self, *, block_ms: int = 5000, count: int = 1) -> Optional[RedisMessage]:
         try:
             reply = await self._client.xreadgroup(

--- a/src/infrastructure/supabase_repos.py
+++ b/src/infrastructure/supabase_repos.py
@@ -126,18 +126,32 @@ class SupabaseJobsRepository(_BaseRepository):
         super().__init__(db)
 
     async def create_job(self, *, job_id: str, file_url: str) -> None:
+        await self.create_jobs_bulk([{"job_id": job_id, "file_url": file_url}])
+
+    async def create_jobs_bulk(self, jobs_data: list[dict[str, Any]]) -> None:
+        if not jobs_data:
+            return
+
+        now = datetime.now(timezone.utc)
+        records = [
+            (
+                j["job_id"],
+                "PENDING",
+                j["file_url"],
+                now,
+                now,
+            )
+            for j in jobs_data
+        ]
+
         pool = await self._get_pool()
         async with pool.acquire() as conn:
-            await conn.execute(
+            await conn.executemany(
                 """
                 INSERT INTO processing_jobs (job_id, status, file_url, created_at, updated_at)
                 VALUES ($1, $2, $3, $4, $5)
                 """,
-                job_id,
-                "PENDING",
-                file_url,
-                datetime.now(timezone.utc),
-                datetime.now(timezone.utc),
+                records,
             )
 
     async def get_file_url(self, job_id: str) -> Optional[str]:

--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -18,12 +18,20 @@ class DummyQueue:
         self.enqueued.append({"job_id": job_id, "file_path": file_path})
         return "1-0"
 
+    async def enqueue_jobs_bulk(self, jobs_data: list[dict[str, Any]]) -> list[str]:
+        for job in jobs_data:
+            self.enqueued.append({"job_id": job["job_id"], "file_path": job["file_path"]})
+        return [f"1-{i}" for i in range(len(jobs_data))]
+
     async def close(self) -> None:
         return None
 
 
 class DummyJobsRepo:
     async def create_job(self, *, job_id: str, file_url: str) -> None:
+        return None
+
+    async def create_jobs_bulk(self, jobs_data: list[dict[str, Any]]) -> None:
         return None
 
 


### PR DESCRIPTION
- Add create_jobs_bulk to SupabaseJobsRepository using executemany.
- Add enqueue_jobs_bulk to RedisQueue using pipelines.
- Update /ingest route to use bulk methods, eliminating N+1 I/O pattern.
- Update tests to support bulk operations.