### PR TITLE
⚡ Bolt: Use connection pool for /health endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+## 2024-05-27 - [Health Check Connection Pool]
+**Learning:** Establishing a brand new asyncpg database connection (with TLS handshake and authentication) for every single request on high-frequency API endpoints like `/health` creates unnecessary overhead and latency.
+**Action:** Always import and reuse `get_connection_pool` from `src.infrastructure.supabase_repos` instead of creating direct database connections (`asyncpg.connect()`).

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository, get_connection_pool
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -309,13 +309,14 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            # ⚡ Bolt Optimization:
+            # Reusing the shared connection pool prevents a costly TCP/TLS handshake
+            # and authentication overhead on every single /health request.
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
                 return {"ok": True}
-            finally:
-                await conn.close()
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
💡 What: Replaced direct `asyncpg.connect()` calls in the `/health` endpoint with a shared connection pool via `get_connection_pool()`.
🎯 Why: The `/health` endpoint is polled frequently. Establishing a new TCP/TLS connection and authenticating for every single request creates significant overhead and latency.
📊 Impact: Eliminates database handshake time for health checks, reducing endpoint latency and database connection churn.
🔬 Measurement: Verify by running tests (`pytest tests/`) and observing reduced latency/connections during load testing on the `/health` endpoint.

---
*PR created automatically by Jules for task [3824477002793660131](https://jules.google.com/task/3824477002793660131) started by @kourdroid*