### PR TITLE
⚡ Bolt: Optimize /health endpoint database connections

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+
+## 2026-05-28 - [Health Check Connection Pooling]
+**Learning:** Creating direct database connections (`asyncpg.connect`) on every call to high-frequency endpoints like `/health` introduces significant overhead from TCP/TLS handshakes and database authentication.
+**Action:** Always import and reuse the shared connection pool (`get_connection_pool`) using the `async with pool.acquire()` pattern for high-frequency or lightweight API endpoints to mitigate latency and connection exhaustion.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,11 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import (
+    SupabaseJobsRepository,
+    SupabaseRegistryRepository,
+    get_connection_pool,
+)
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -309,13 +313,16 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            # ⚡ Bolt Optimization:
+            # Replaced direct `asyncpg.connect()` with `get_connection_pool()`.
+            # Creating a new DB connection for every /health check incurs expensive
+            # TCP/TLS handshakes and auth overhead. Reusing the pool prevents
+            # latency spikes and reduces database load under high health-check frequency.
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
                 return {"ok": True}
-            finally:
-                await conn.close()
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
💡 What: Replaced direct `asyncpg.connect()` calls with a shared connection pool (`get_connection_pool`) in the `/health` endpoint.
🎯 Why: The `/health` endpoint is called frequently. Creating a new database connection for every check introduces significant overhead (TCP/TLS handshake, authentication). Reusing a connection pool mitigates this connection latency.
📊 Impact: Reduces database load and latency for health checks significantly.
🔬 Measurement: Review connection count metrics on the database before and after deployment, and measure latency of the `/health` endpoint.

---
*PR created automatically by Jules for task [8085662100468793002](https://jules.google.com/task/8085662100468793002) started by @kourdroid*