### PR TITLE
⚡ Bolt: Use DB connection pool in health endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+
+## 2024-11-21 - [Database Connection Pools in Health Checks]
+**Learning:** Direct `asyncpg.connect()` calls inside high-frequency endpoints like `/health` cause expensive TCP/TLS handshake and database authentication overhead on each request.
+**Action:** Always reuse a shared connection pool (e.g., `get_connection_pool`) for health checks and API endpoints rather than spawning direct database connections.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository, get_connection_pool
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -309,13 +309,16 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            # ⚡ Bolt Optimization:
+            # Reusing the shared connection pool for the health check instead of
+            # opening a new direct connection via asyncpg.connect(). This prevents
+            # expensive TCP/TLS handshake and database authentication overhead,
+            # significantly reducing latency on high-frequency health probes.
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
                 return {"ok": True}
-            finally:
-                await conn.close()
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
⚡ Bolt: Use DB connection pool in health endpoint

💡 What: Updated the `/health` endpoint in `src/api/routes.py` to reuse the shared `asyncpg` connection pool via `get_connection_pool` rather than creating a direct database connection with `asyncpg.connect()` on every probe.
🎯 Why: High-frequency endpoints like `/health` suffer significant latency from the TCP/TLS handshake and Postgres authentication overhead if a new connection is spawned on every request. Reusing the pool fixes this bottleneck.
📊 Impact: Reduces database authentication load and dramatically lowers response time latency on health probes. Expected O(1) negligible latency for connection acquisition vs ~50-100ms for establishing a new connection.
🔬 Measurement: Verified the code using Python's `py_compile` and successfully ran the pytest suite locally to ensure no functionality is broken. Added a journal entry about this anti-pattern.

---
*PR created automatically by Jules for task [17940788965168793423](https://jules.google.com/task/17940788965168793423) started by @kourdroid*