### PR TITLE
⚡ Bolt: Use DB connection pooling in health endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+
+## 2024-11-20 - [Avoid high-frequency DB Connections]
+**Learning:** Establishing direct connections (`asyncpg.connect()`) within high-frequency API endpoints like `/health` causes expensive TCP/TLS handshake latency and wastes connection limits.
+**Action:** Utilize shared connection pooling (e.g. `get_connection_pool`) and borrow connections via `pool.acquire()` to prevent performance bottlenecks.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,11 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import (
+    SupabaseJobsRepository,
+    SupabaseRegistryRepository,
+    get_connection_pool,
+)
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -309,13 +313,11 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
-                return {"ok": True}
-            finally:
-                await conn.close()
+            return {"ok": True}
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
Updated the `/health` endpoint in `src/api/routes.py` to use `get_connection_pool` from `src.infrastructure.supabase_repos` instead of establishing a new connection via `asyncpg.connect()` on every request.

This avoids expensive direct connection handshakes in a high frequency endpoint. Evaluated via unit testing.

---
*PR created automatically by Jules for task [14614015854046731485](https://jules.google.com/task/14614015854046731485) started by @kourdroid*