### PR TITLE
⚡ Bolt: Optimize /health endpoint with database connection pooling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+
+## 2024-11-21 - [Connection Pooling in High-Frequency Endpoints]
+**Learning:** Making direct database connections (`asyncpg.connect()`) in high-frequency APIs like `/health` introduces expensive TCP/TLS handshake overhead that degrades overall application performance.
+**Action:** Always import and reuse `get_connection_pool` from `src.infrastructure.supabase_repos` to acquire shared connections for stateless, high-frequency endpoint checks.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,11 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import (
+    SupabaseJobsRepository,
+    SupabaseRegistryRepository,
+    get_connection_pool,
+)
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -309,13 +313,14 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            # ⚡ Bolt Optimization:
+            # Use connection pool instead of creating a new connection per request.
+            # Avoids expensive TCP/TLS handshake and authentication overhead on high-frequency /health checks.
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
                 return {"ok": True}
-            finally:
-                await conn.close()
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
💡 What: Replaced direct `asyncpg.connect()` calls with a shared connection pool (`get_connection_pool`) in the `/health` endpoint.
🎯 Why: Creating a new connection for every single `/health` check introduces expensive TCP/TLS handshake and authentication overhead, making it a performance bottleneck on high-frequency requests.
📊 Impact: Expected to significantly reduce latency on health checks and lower overall database connection thrashing by reusing established connections from the pool.
🔬 Measurement: Verify by executing a load test against the `/health` endpoint and observing lower average latency and reduced CPU/network overhead on the PostgreSQL server.

---
*PR created automatically by Jules for task [12308277091834402018](https://jules.google.com/task/12308277091834402018) started by @kourdroid*