### PR TITLE
⚡ Bolt: Add LRU caching and regex pre-compilation to 3-way match string normalization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+
+## 2024-06-05 - [3-Way Match String Normalization Redundancy]
+**Learning:** The `_normalize_description` function in `src/plugins/supply_chain.py` is called inside nested loops comparing N invoice items to M PO/receipt items, causing O(N*M) redundant regex computations and string operations for the same descriptions.
+**Action:** Pre-compile the regex and use `@functools.lru_cache` on a string-only helper function to cache normalization results. Always cast inputs to hashable types (like `str`) before caching to avoid `TypeError: unhashable type`.

--- a/src/plugins/supply_chain.py
+++ b/src/plugins/supply_chain.py
@@ -7,12 +7,15 @@ Compares: Invoice (extracted) vs Purchase Order vs Goods Receipt.
 
 from __future__ import annotations
 
+import functools
 import logging
 import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Pre-compile the regex to avoid redundant recompilation in loops
+_NON_ALPHANUMERIC_RE = re.compile(r"[^a-z0-9]+")
 
 def _coerce_float(value: Any) -> float:
     try:
@@ -21,10 +24,20 @@ def _coerce_float(value: Any) -> float:
         return 0.0
 
 
-def _normalize_description(value: Any) -> str:
-    text = str(value or "").lower().strip()
-    text = re.sub(r"[^a-z0-9]+", " ", text)
+@functools.lru_cache(maxsize=1024)
+def _cached_normalize_string(text: str) -> str:
+    """Cached helper for string normalization to avoid O(N*M) redundant computations."""
+    text = text.lower().strip()
+    text = _NON_ALPHANUMERIC_RE.sub(" ", text)
     return " ".join(text.split())
+
+
+def _normalize_description(value: Any) -> str:
+    """
+    Safely cast to string before calling the cached helper
+    to ensure unhashable types do not break lru_cache.
+    """
+    return _cached_normalize_string(str(value or ""))
 
 
 def _match_score(left: str, right: str) -> float:


### PR DESCRIPTION
💡 What: The optimization implemented
- Abstracted `_normalize_description` core string parsing logic into an LRU cached helper, `_cached_normalize_string`.
- Pre-compiled the repeated regex pattern `[^a-z0-9]+` globally to `_NON_ALPHANUMERIC_RE`.
- Ensured the `lru_cache` behaves safely by casting the `Any` input value to a string first to avoid `TypeError: unhashable type`.

🎯 Why: The performance problem it solves
The 3-way match algorithm loops over N invoice items, and for each item, loops over M purchase order lines and M receipt lines. Previously, string normalization and regex pattern recompilation happened on every single iteration inside this O(N*M) loop. This was a purely redundant CPU operation for repetitive strings.

📊 Impact: Expected performance improvement
Eliminates redundant string manipulations and regex compilations during 3-way item matching. Normalizing any repeated text in an invoice description, PO, or goods receipt will now execute in O(1) cache lookup time rather than recomputing the regex replacement repeatedly.

🔬 Measurement: How to verify the improvement
- Run `source .venv/bin/activate && pytest` to confirm tests remain intact.
- A profile against large PO lists using `%timeit` should show a marked reduction in processing time inside the `execute_3_way_match` method.

---
*PR created automatically by Jules for task [2057689219386678662](https://jules.google.com/task/2057689219386678662) started by @kourdroid*