### PR TITLE
⚡ Bolt: Use database connection pool for health check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+## 2025-03-09 - [Direct DB connections in endpoints]
+**Learning:** Establishing direct database connections inside frequent API endpoints (like `/health`) causes performance bottlenecks due to TCP/TLS handshakes and wastes database connection slots.
+**Action:** Always verify if a connection pool util (e.g., `get_connection_pool`) is available to reuse connections instead of creating new ones per request.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository, get_connection_pool
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -309,13 +309,16 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            # ⚡ Bolt Optimization:
+            # Replaced `asyncpg.connect(...)` with `get_connection_pool` to reuse
+            # the existing shared database connection pool instead of creating a new
+            # connection for every health check request. This prevents expensive
+            # TCP/TLS handshakes and saves database connection slots.
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
                 return {"ok": True}
-            finally:
-                await conn.close()
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
💡 What: Replaced direct `asyncpg.connect(...)` with `get_connection_pool()` in the `/health` endpoint.
🎯 Why: Establishing a new database connection for every health check request causes unnecessary performance overhead due to TCP/TLS handshakes and consumes database connection slots rapidly.
📊 Impact: Eliminates database connection overhead for the health endpoint, avoiding potential connection exhaustion under high polling frequency and reducing response latency.
🔬 Measurement: Run `pytest` to ensure tests continue to pass. The `/health` endpoint should respond instantly.

---
*PR created automatically by Jules for task [5039978964566786173](https://jules.google.com/task/5039978964566786173) started by @kourdroid*