### PR TITLE
⚡ Bolt: optimize database sorting queries in /jobs endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+## 2024-11-20 - [Database Query Performance for the /jobs Endpoint]
+**Learning:** The `/jobs` API endpoint queries the `processing_jobs` table using filters by `status` and orders by `created_at DESC`. Without a composite index `(status, created_at DESC)`, PostgreSQL performs a sequential scan and full table sort, taking O(N log N) time which bottlenecks as the application processes more jobs.
+**Action:** Adding composite and simple indices on the fields used in the `ORDER BY` clause turns these sorts into an efficient backward B-Tree index scan in O(LIMIT) time.

--- a/sql/004_add_processing_jobs_index.sql
+++ b/sql/004_add_processing_jobs_index.sql
@@ -1,0 +1,7 @@
+-- 1. Index for filtering by status and sorting by created_at DESC
+CREATE INDEX IF NOT EXISTS idx_processing_jobs_status_created_at
+ON processing_jobs (status, created_at DESC);
+
+-- 2. Index for sorting by created_at DESC (when no status filter is applied)
+CREATE INDEX IF NOT EXISTS idx_processing_jobs_created_at
+ON processing_jobs (created_at DESC);

--- a/src/infrastructure/supabase_repos.py
+++ b/src/infrastructure/supabase_repos.py
@@ -205,6 +205,11 @@ class SupabaseJobsRepository(_BaseRepository):
         limit: int = 50,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
+        # ⚡ Bolt Optimization:
+        # Queries below rely on the indexes idx_processing_jobs_status_created_at
+        # and idx_processing_jobs_created_at to avoid O(N log N) full table sorts.
+        # This reduces the query time to O(LIMIT) since PostgreSQL can simply walk
+        # the B-Tree index backwards to satisfy the ORDER BY ... DESC clause.
         pool = await self._get_pool()
         async with pool.acquire() as conn:
             if status:


### PR DESCRIPTION
💡 What: Added database indexes on `processing_jobs` for `(status, created_at DESC)` and `(created_at DESC)` and documented the performance characteristics in the codebase.
🎯 Why: The `/jobs` API endpoint queries the `processing_jobs` table by `status` (optional) and orders by `created_at DESC`. Without these indexes, PostgreSQL performs a sequential scan and a full table sort, taking O(N log N) time, which creates a bottleneck as the dataset grows.
📊 Impact: Reduces query time from O(N log N) to O(LIMIT) for the `/jobs` endpoint. The B-Tree indexes allow PostgreSQL to simply walk the tree backward to satisfy the ordering clause instead of performing an in-memory or disk sort.
🔬 Measurement: Verify by executing an `EXPLAIN ANALYZE` on `SELECT * FROM processing_jobs ORDER BY created_at DESC LIMIT 50;` to observe it using an Index Scan Backwards rather than a Sort operation. Run tests with `pytest` to ensure no functionality is broken.

---
*PR created automatically by Jules for task [12012711037287678814](https://jules.google.com/task/12012711037287678814) started by @kourdroid*