### PR TITLE
⚡ Bolt: Optimize /health endpoint with database connection pooling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+## 2024-05-18 - [Optimizing the /health endpoint with connection pooling]
+**Learning:** High-frequency API endpoints like `/health`, when backed by PostgreSQL databases, suffer severely from TCP/TLS handshake latency if new connections are spawned directly (e.g., via `asyncpg.connect()`).
+**Action:** Use a shared connection pool (`get_connection_pool` from `src.infrastructure.supabase_repos`) for all database operations on standard HTTP endpoints to prevent unnecessary overhead and potential connection limits.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository, get_connection_pool
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -309,13 +309,16 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            # ⚡ Bolt Optimization:
+            # Use `get_connection_pool` to acquire a shared database connection instead of
+            # creating a new `asyncpg.connect()` on every `/health` request.
+            # This avoids expensive TCP/TLS handshakes and PostgreSQL authentication overhead
+            # which is critical for a high-frequency endpoint often polled by load balancers.
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
                 return {"ok": True}
-            finally:
-                await conn.close()
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
💡 **What:** Replaced the direct `asyncpg.connect()` call in the `/health` API endpoint with `get_connection_pool()`.

🎯 **Why:** The `/health` endpoint is typically polled frequently by orchestrators and load balancers. Creating a new, unpooled database connection on each request adds massive overhead through repeated TCP handshakes and database authentication processes, introducing latency and increasing the risk of exhausting DB connections under load.

📊 **Impact:** Significantly reduces the latency of the `/health` endpoint and drastically reduces load on the PostgreSQL server since connections are reused instead of being recreated from scratch.

🔬 **Measurement:** Verify by running performance tests on the `/health` endpoint (e.g., using `wrk` or `artillery`). You should see lower latency and fewer new DB connection logs. Run `pytest` to confirm health endpoint functions reliably return ok when passing.

---
*PR created automatically by Jules for task [3856518517046530820](https://jules.google.com/task/3856518517046530820) started by @kourdroid*