### PR TITLE
⚡ Bolt: Use connection pooling for concurrent Supabase storage uploads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+## 2024-05-24 - [Avoid TLS handshake bottleneck with connection pooling in Storage Layer]
+**Learning:** Instantiating `httpx.AsyncClient` inside tight loops for multiple parallel uploads creates immense overhead due to repeated TCP connection initialization and TLS handshakes. Even with `asyncio.gather`, a new client per file drastically limits throughput.
+**Action:** Always implement Storage clients as an async context manager and inject a shared HTTP client during its lifecycle. In `SupabaseStorage`, implementing `__aenter__`/`__aexit__` allows sharing a single connection pool across all queued tasks inside a batch, turning O(N) connection overhead into O(1). Remember to also add these dunder methods to test mocks.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -4,14 +4,13 @@ import asyncio
 import logging
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 import aiofiles
 import asyncpg
 import tempfile
 import redis.asyncio as redis
 from fastapi import APIRouter, HTTPException, Query, UploadFile
-from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from src.config import get_settings
@@ -68,18 +67,12 @@ async def ingest(file: UploadFile) -> IngestResponse:
     if not settings.supabase_url or not settings.supabase_service_role_key:
         raise HTTPException(status_code=500, detail="Supabase Storage not configured")
 
-    storage = SupabaseStorage(
-        settings.supabase_url,
-        settings.supabase_service_role_key,
-        timeout_s=settings.storage_upload_timeout_s,
-    )
-
     job_id = str(uuid.uuid4())
 
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
             target_path = Path(tmpdir) / f"{job_id}.pdf"
-            
+
             content = await file.read()
             if not content:
                 logger.error("step=ingest status=failed reason=empty_file")
@@ -99,31 +92,39 @@ async def ingest(file: UploadFile) -> IngestResponse:
             try:
                 upload_tasks = []
                 sp_job_ids = []
-                for split_index, sp in enumerate(split_paths, start=1):
-                    sp_job_id = str(uuid.uuid4())
-                    sp_job_ids.append(sp_job_id)
-                    split_name = Path(sp).name
-                    logger.info(
-                        "step=ingest split_process status=start split_index=%s total_splits=%s split_file=%s",
-                        split_index,
-                        len(split_paths),
-                        split_name,
-                    )
-                    file_bytes = Path(sp).read_bytes()
-                    upload_tasks.append(storage.upload(f"{sp_job_id}.pdf", file_bytes))
 
-                try:
-                    # ⚡ Bolt Optimization:
-                    # Execute all storage uploads concurrently using asyncio.gather
-                    # This replaces the N+1 sequential await calls inside the loop,
-                    # reducing total upload time from O(N) to roughly O(1) for split PDFs.
-                    public_urls = await asyncio.gather(*upload_tasks)
-                except Exception as exc:
-                    logger.exception(
-                        "step=ingest split_process status=failed phase=upload total_splits=%s",
-                        len(split_paths),
-                    )
-                    raise SplitEnqueueError(phase="upload", split_file="multiple_splits", original_error=exc) from exc
+                async with SupabaseStorage(
+                    settings.supabase_url,
+                    settings.supabase_service_role_key,
+                    timeout_s=settings.storage_upload_timeout_s,
+                ) as storage:
+                    for split_index, sp in enumerate(split_paths, start=1):
+                        sp_job_id = str(uuid.uuid4())
+                        sp_job_ids.append(sp_job_id)
+                        split_name = Path(sp).name
+                        logger.info(
+                            "step=ingest split_process status=start split_index=%s total_splits=%s split_file=%s",
+                            split_index,
+                            len(split_paths),
+                            split_name,
+                        )
+                        file_bytes = Path(sp).read_bytes()
+                        upload_tasks.append(storage.upload(f"{sp_job_id}.pdf", file_bytes))
+
+                    try:
+                        # ⚡ Bolt Optimization:
+                        # Execute all storage uploads concurrently using asyncio.gather
+                        # This replaces the N+1 sequential await calls inside the loop,
+                        # reducing total upload time from O(N) to roughly O(1) for split PDFs.
+                        public_urls = await asyncio.gather(*upload_tasks)
+                    except Exception as exc:
+                        logger.exception(
+                            "step=ingest split_process status=failed phase=upload total_splits=%s",
+                            len(split_paths),
+                        )
+                        raise SplitEnqueueError(
+                            phase="upload", split_file="multiple_splits", original_error=exc
+                        ) from exc
 
                 for sp_job_id, public_url in zip(sp_job_ids, public_urls):
                     jobs_to_create.append(
@@ -143,7 +144,9 @@ async def ingest(file: UploadFile) -> IngestResponse:
                             "step=ingest split_process status=failed phase=create_jobs_bulk total_splits=%s",
                             len(split_paths),
                         )
-                        raise SplitEnqueueError(phase="create_jobs_bulk", split_file="all_splits", original_error=exc) from exc
+                        raise SplitEnqueueError(
+                            phase="create_jobs_bulk", split_file="all_splits", original_error=exc
+                        ) from exc
 
                     try:
                         await queue.enqueue_jobs_bulk(jobs_to_create)
@@ -152,7 +155,9 @@ async def ingest(file: UploadFile) -> IngestResponse:
                             "step=ingest split_process status=failed phase=enqueue_jobs_bulk total_splits=%s",
                             len(split_paths),
                         )
-                        raise SplitEnqueueError(phase="enqueue_jobs_bulk", split_file="all_splits", original_error=exc) from exc
+                        raise SplitEnqueueError(
+                            phase="enqueue_jobs_bulk", split_file="all_splits", original_error=exc
+                        ) from exc
             except Exception as exc:
                 logger.exception("step=ingest enqueue_failed count=%s", len(job_ids))
                 for jid in job_ids:

--- a/src/infrastructure/supabase_storage.py
+++ b/src/infrastructure/supabase_storage.py
@@ -20,28 +20,46 @@ class SupabaseStorage:
             "Authorization": f"Bearer {self.service_role_key}",
             "apikey": self.service_role_key,
         }
+        self._client = None
+
+    async def __aenter__(self):
+        self._client = httpx.AsyncClient(timeout=self.timeout)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self._client:
+            await self._client.aclose()
+            self._client = None
 
     async def upload(self, path: str, data: bytes, content_type: str = "application/pdf") -> str:
         """Upload file, return public URL."""
         url = f"{self.supabase_url}/storage/v1/object/{self.BUCKET}/{path}"
-        
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            resp = await client.post(
-                url,
-                content=data,
-                headers={**self.headers, "Content-Type": content_type},
-            )
+
+        headers = {**self.headers, "Content-Type": content_type}
+
+        if self._client:
+            resp = await self._client.post(url, content=data, headers=headers)
             resp.raise_for_status()
-            
+        else:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.post(url, content=data, headers=headers)
+                resp.raise_for_status()
+
         return self.get_public_url(path)
 
     async def download(self, path: str) -> bytes:
         """Download file bytes."""
         url = f"{self.supabase_url}/storage/v1/object/{self.BUCKET}/{path}"
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            resp = await client.get(url, headers=self.headers)
+
+        if self._client:
+            resp = await self._client.get(url, headers=self.headers)
             resp.raise_for_status()
             return resp.content
+        else:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.get(url, headers=self.headers)
+                resp.raise_for_status()
+                return resp.content
 
     def get_public_url(self, path: str) -> str:
         """Construct the public URL without an API call."""

--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -38,6 +38,12 @@ class DummyStorage:
     def __init__(self, *_args, **_kwargs) -> None:
         pass
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
     async def upload(self, path: str, data: bytes, content_type: str = "application/pdf") -> str:
         return "http://example.com/file.pdf"
 

--- a/tests/test_api_ingest_split_failure.py
+++ b/tests/test_api_ingest_split_failure.py
@@ -34,6 +34,12 @@ class FailingStorage:
     def __init__(self, *_args, **_kwargs) -> None:
         return None
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
     async def upload(self, path: str, data: bytes, content_type: str = "application/pdf") -> str:
         raise TimeoutError("storage upload timed out")
 


### PR DESCRIPTION
💡 What: Implemented `__aenter__` and `__aexit__` in `SupabaseStorage` to support acting as an asynchronous context manager, sharing a single `httpx.AsyncClient` across sequential/concurrent upload requests. Updated the `/ingest` route to wrap storage upload logic inside an `async with` block, and updated relevant test mocks to behave correctly as context managers.

🎯 Why: Previously, during PDF splitting in the `/ingest` route, the system instantiated a new `SupabaseStorage` client, but the underlying HTTP client (`httpx.AsyncClient`) was instantiated inside the `upload` method on every call. This meant that each concurrent upload (even though batched using `asyncio.gather`) was opening a brand new TCP connection and performing a full TLS handshake, causing a severe N+1 latency bottleneck.

📊 Impact: Reduces storage upload connection overhead from O(N) to O(1) by reusing a single HTTP client connection pool across all uploaded split chunks.

🔬 Measurement: Verify by running `pytest tests/test_api_ingest.py` and reviewing logs for the `/ingest` endpoint to ensure uploads still succeed but execute significantly faster under load.

---
*PR created automatically by Jules for task [3448507274474855146](https://jules.google.com/task/3448507274474855146) started by @kourdroid*