### PR TITLE
⚡ Bolt: Use connection pool in /health endpoint to eliminate connection overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-11-20 - [Concurrent PDF Uploads]
 **Learning:** In backend endpoints processing multiple splits sequentially (like PDF uploads to Supabase), `await` inside a loop creates an N+1 latency bottleneck.
 **Action:** Extract the I/O-bound tasks into a list and use `await asyncio.gather(*tasks)` to run them concurrently, dramatically reducing overall request time.
+
+## 2024-11-20 - [Connection Pooling in High-Frequency Endpoints]
+**Learning:** Establishing direct database connections (e.g., using `asyncpg.connect()`) in high-frequency endpoints like `/health` causes significant overhead due to repetitive TCP/TLS handshakes and authentication, which can lead to connection exhaustion and increased latency.
+**Action:** Always use a shared database connection pool (e.g., `get_connection_pool`) for endpoints that are called frequently, such as health checks, to reuse connections and reduce overhead.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository, get_connection_pool
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -309,13 +309,11 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
                 return {"ok": True}
-            finally:
-                await conn.close()
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
💡 **What**: The `/health` endpoint now fetches a shared database connection pool using `get_connection_pool` rather than establishing a direct connection with `asyncpg.connect()`.

🎯 **Why**: Establishing a direct connection to PostgreSQL via `asyncpg.connect()` on every health check request incurs significant overhead from TCP/TLS handshakes and database authentication. Since health checks are typically polled at high frequencies by load balancers, orchestrators, or monitors, this pattern can exhaust database connections, cause connection timeouts, and introduce high latency.

📊 **Impact**: Reduces health check latency significantly and prevents connection exhaustion during high-frequency polling. By reusing connections from the global async pool, we shift from an O(1) connection setup per request to O(~0) overhead per request (amortised).

🔬 **Measurement**: 
1. Run a load test or simple loop triggering the `/health` endpoint.
2. Observe the latency of the `/health` endpoint before and after.
3. Observe the total active connection count on the PostgreSQL database (it should remain stable and low rather than spiking with each request).

---
*PR created automatically by Jules for task [444817928170142499](https://jules.google.com/task/444817928170142499) started by @kourdroid*