### PR TITLE
⚡ Bolt: Add database indexes to optimize jobs pagination

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - [Regex Pre-compilation and LRU Caching]
 **Learning:** Functions called frequently in tight loops (like `_normalize_description` and `_sanitize_for_match`) can become bottlenecks due to repeated compilation of identical regular expressions.
 **Action:** Pre-compile regular expressions using `re.compile()` at the module level. Furthermore, when a string normalization function accepts an `Any` type, wrap it with `@functools.lru_cache` but cast the argument to `str` first to avoid `TypeError: unhashable type`.
+## 2026-07-10 - [Database Index for Pagination]
+**Learning:** The `GET /jobs` endpoint in `src/api/routes.py` performs an `ORDER BY created_at DESC` query with optional `WHERE status = $1` filtering. Without indexes, PostgreSQL executes expensive O(N log N) full-table sorts on the `processing_jobs` table.
+**Action:** Add B-Tree indexes on `(status, created_at DESC)` and `(created_at DESC)` using `CREATE INDEX CONCURRENTLY` to optimize these queries to O(LIMIT) backwards index scans without blocking production writes.

--- a/sql/004_add_jobs_pagination_indexes.sql
+++ b/sql/004_add_jobs_pagination_indexes.sql
@@ -1,0 +1,11 @@
+-- Optimize `GET /jobs` pagination queries
+-- Adding these indexes allows PostgreSQL to use B-Tree backwards index scans,
+-- turning O(N log N) file sorts into fast O(LIMIT) lookups.
+
+-- Index for queries filtering by status: `SELECT ... WHERE status = $1 ORDER BY created_at DESC LIMIT ...`
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_processing_jobs_status_created_at
+ON processing_jobs (status, created_at DESC);
+
+-- Index for queries without status filter: `SELECT ... ORDER BY created_at DESC LIMIT ...`
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_processing_jobs_created_at
+ON processing_jobs (created_at DESC);


### PR DESCRIPTION
💡 **What:** Added a new SQL migration script (`004_add_jobs_pagination_indexes.sql`) that safely creates `CONCURRENT` B-Tree indexes on the `processing_jobs` table for `(status, created_at DESC)` and `(created_at DESC)`.

🎯 **Why:** The `GET /jobs` API endpoint allows paginating through processed jobs, which inherently requires sorting by `created_at DESC` and filtering by `status`. Without matching indexes, PostgreSQL executes expensive `O(N log N)` in-memory or on-disk sorts for every request. As the database grows, this becomes a severe latency bottleneck.

📊 **Impact:** Turns `O(N log N)` full-table sorts into `O(LIMIT)` fast backwards index scans. The API response time will now remain fast and constant (`O(1)`) regardless of how many millions of jobs exist in the system.

🔬 **Measurement:** Execute `EXPLAIN ANALYZE SELECT * FROM processing_jobs ORDER BY created_at DESC LIMIT 50;`. The query plan will switch from "Sort" -> "Seq Scan" to "Index Scan Backwards" on the new index.

---
*PR created automatically by Jules for task [8636761640252526887](https://jules.google.com/task/8636761640252526887) started by @kourdroid*