### PR TITLE
⚡ Bolt: Add indexes to processing_jobs to optimize /jobs endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - [Regex Pre-compilation and LRU Caching]
 **Learning:** Functions called frequently in tight loops (like `_normalize_description` and `_sanitize_for_match`) can become bottlenecks due to repeated compilation of identical regular expressions.
 **Action:** Pre-compile regular expressions using `re.compile()` at the module level. Furthermore, when a string normalization function accepts an `Any` type, wrap it with `@functools.lru_cache` but cast the argument to `str` first to avoid `TypeError: unhashable type`.
+## 2024-11-20 - [Avoid direct asyncpg.connect in high-frequency endpoints]
+**Learning:** In endpoints that are hit frequently like `/health`, creating a direct database connection via `asyncpg.connect` is extremely slow and resource intensive due to the TCP/TLS handshakes and authentication overhead.
+**Action:** Always use the shared connection pool wrapper `get_connection_pool` to retrieve connections. This eliminates the overhead of opening a new physical connection per request.

--- a/sql/004_processing_jobs_indexes.sql
+++ b/sql/004_processing_jobs_indexes.sql
@@ -1,0 +1,10 @@
+-- Migration: Add indexes to optimize /jobs API endpoint
+-- Use CONCURRENTLY to avoid locking the table during index creation
+
+-- Index for filtering by status and sorting by created_at DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_processing_jobs_status_created_at
+ON processing_jobs (status, created_at DESC);
+
+-- Index for sorting by created_at DESC when no status filter is applied
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_processing_jobs_created_at
+ON processing_jobs (created_at DESC);


### PR DESCRIPTION
💡 **What:** Added a SQL migration (`004_processing_jobs_indexes.sql`) to create database indexes on the `processing_jobs` table. The indexes are `(status, created_at DESC)` and `(created_at DESC)`.
🎯 **Why:** The `/jobs` API endpoint queries the `processing_jobs` table and orders the results by `created_at DESC`, optionally filtering by `status`. Without indexes, these queries result in sequential scans and expensive O(N log N) sorts.
📊 **Impact:** This optimization turns the O(N log N) sorts into O(LIMIT) B-Tree backward walks. It will significantly reduce the latency of the `/jobs` endpoint and lower CPU/IO load on the database, particularly as the table grows large.
🔬 **Measurement:** Execute `EXPLAIN ANALYZE` on the following query before and after applying the migration: `SELECT * FROM processing_jobs WHERE status = 'PENDING' ORDER BY created_at DESC LIMIT 50;`. The query plan should shift from `Seq Scan` + `Sort` to an `Index Scan` (or `Index Only Scan`) on the newly created index.

---
*PR created automatically by Jules for task [3438726045328796059](https://jules.google.com/task/3438726045328796059) started by @kourdroid*