### PR TITLE
⚡ Bolt: Use shared httpx.AsyncClient for concurrent uploads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - [Regex Pre-compilation and LRU Caching]
 **Learning:** Functions called frequently in tight loops (like `_normalize_description` and `_sanitize_for_match`) can become bottlenecks due to repeated compilation of identical regular expressions.
 **Action:** Pre-compile regular expressions using `re.compile()` at the module level. Furthermore, when a string normalization function accepts an `Any` type, wrap it with `@functools.lru_cache` but cast the argument to `str` first to avoid `TypeError: unhashable type`.
+## 2026-07-13 - [Shared HTTP Client Context]
+**Learning:** Instantiating a new `httpx.AsyncClient` per request inside concurrent tasks (like `asyncio.gather`) incurs significant TCP/TLS handshake overhead. Attempting to store an `httpx.AsyncClient` on a request-scoped class instance via `__aenter__` can lead to race conditions if not careful.
+**Action:** When making concurrent HTTP requests, instantiate an `httpx.AsyncClient` using an `async with` block surrounding the iteration logic and pass the shared `client` instance down into the service method to avoid handshake overhead and global state mutation.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -6,6 +6,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Optional
 
+import httpx
 import aiofiles
 import asyncpg
 import tempfile
@@ -99,31 +100,35 @@ async def ingest(file: UploadFile) -> IngestResponse:
             try:
                 upload_tasks = []
                 sp_job_ids = []
-                for split_index, sp in enumerate(split_paths, start=1):
-                    sp_job_id = str(uuid.uuid4())
-                    sp_job_ids.append(sp_job_id)
-                    split_name = Path(sp).name
-                    logger.info(
-                        "step=ingest split_process status=start split_index=%s total_splits=%s split_file=%s",
-                        split_index,
-                        len(split_paths),
-                        split_name,
-                    )
-                    file_bytes = Path(sp).read_bytes()
-                    upload_tasks.append(storage.upload(f"{sp_job_id}.pdf", file_bytes))
+                # ⚡ Bolt Optimization:
+                # Use a shared httpx.AsyncClient across all concurrent split uploads
+                # to avoid expensive TLS/connection handshakes for each file.
+                async with httpx.AsyncClient(timeout=storage.timeout) as client:
+                    for split_index, sp in enumerate(split_paths, start=1):
+                        sp_job_id = str(uuid.uuid4())
+                        sp_job_ids.append(sp_job_id)
+                        split_name = Path(sp).name
+                        logger.info(
+                            "step=ingest split_process status=start split_index=%s total_splits=%s split_file=%s",
+                            split_index,
+                            len(split_paths),
+                            split_name,
+                        )
+                        file_bytes = Path(sp).read_bytes()
+                        upload_tasks.append(storage.upload(f"{sp_job_id}.pdf", file_bytes, client=client))
 
-                try:
-                    # ⚡ Bolt Optimization:
-                    # Execute all storage uploads concurrently using asyncio.gather
-                    # This replaces the N+1 sequential await calls inside the loop,
-                    # reducing total upload time from O(N) to roughly O(1) for split PDFs.
-                    public_urls = await asyncio.gather(*upload_tasks)
-                except Exception as exc:
-                    logger.exception(
-                        "step=ingest split_process status=failed phase=upload total_splits=%s",
-                        len(split_paths),
-                    )
-                    raise SplitEnqueueError(phase="upload", split_file="multiple_splits", original_error=exc) from exc
+                    try:
+                        # ⚡ Bolt Optimization:
+                        # Execute all storage uploads concurrently using asyncio.gather
+                        # This replaces the N+1 sequential await calls inside the loop,
+                        # reducing total upload time from O(N) to roughly O(1) for split PDFs.
+                        public_urls = await asyncio.gather(*upload_tasks)
+                    except Exception as exc:
+                        logger.exception(
+                            "step=ingest split_process status=failed phase=upload total_splits=%s",
+                            len(split_paths),
+                        )
+                        raise SplitEnqueueError(phase="upload", split_file="multiple_splits", original_error=exc) from exc
 
                 for sp_job_id, public_url in zip(sp_job_ids, public_urls):
                     jobs_to_create.append(

--- a/src/infrastructure/supabase_storage.py
+++ b/src/infrastructure/supabase_storage.py
@@ -21,27 +21,41 @@ class SupabaseStorage:
             "apikey": self.service_role_key,
         }
 
-    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf") -> str:
+    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf", client: httpx.AsyncClient | None = None) -> str:
         """Upload file, return public URL."""
         url = f"{self.supabase_url}/storage/v1/object/{self.BUCKET}/{path}"
         
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
+        if client:
             resp = await client.post(
                 url,
                 content=data,
                 headers={**self.headers, "Content-Type": content_type},
             )
             resp.raise_for_status()
+        else:
+            async with httpx.AsyncClient(timeout=self.timeout) as client_local:
+                resp = await client_local.post(
+                    url,
+                    content=data,
+                    headers={**self.headers, "Content-Type": content_type},
+                )
+                resp.raise_for_status()
             
         return self.get_public_url(path)
 
-    async def download(self, path: str) -> bytes:
+    async def download(self, path: str, client: httpx.AsyncClient | None = None) -> bytes:
         """Download file bytes."""
         url = f"{self.supabase_url}/storage/v1/object/{self.BUCKET}/{path}"
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
+
+        if client:
             resp = await client.get(url, headers=self.headers)
             resp.raise_for_status()
             return resp.content
+        else:
+            async with httpx.AsyncClient(timeout=self.timeout) as client_local:
+                resp = await client_local.get(url, headers=self.headers)
+                resp.raise_for_status()
+                return resp.content
 
     def get_public_url(self, path: str) -> str:
         """Construct the public URL without an API call."""

--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -34,11 +34,13 @@ class DummyJobsRepo:
     async def create_jobs_bulk(self, jobs_data: list[dict[str, Any]]) -> None:
         return None
 
+import httpx
+
 class DummyStorage:
     def __init__(self, *_args, **_kwargs) -> None:
-        pass
+        self.timeout = httpx.Timeout(60.0)
 
-    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf") -> str:
+    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf", client=None) -> str:
         return "http://example.com/file.pdf"
 
 

--- a/tests/test_api_ingest_split_failure.py
+++ b/tests/test_api_ingest_split_failure.py
@@ -30,11 +30,13 @@ class DummyJobsRepo:
         return None
 
 
+import httpx
+
 class FailingStorage:
     def __init__(self, *_args, **_kwargs) -> None:
-        return None
+        self.timeout = httpx.Timeout(60.0)
 
-    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf") -> str:
+    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf", client=None) -> str:
         raise TimeoutError("storage upload timed out")
 
 


### PR DESCRIPTION
💡 **What:** 
Updated `SupabaseStorage` to accept an optional `httpx.AsyncClient` in its `upload` and `download` methods. In `src/api/routes.py`, an `httpx.AsyncClient` is instantiated and shared across all concurrent file uploads in `asyncio.gather`.

🎯 **Why:** 
Previously, a new `httpx.AsyncClient` was instantiated for every split file upload during ingestion. This incurred expensive TCP and TLS handshakes for each HTTP request, creating a performance bottleneck when handling documents with many splits. Attempting to use a request-scoped class context manager (`__aenter__`) could cause race conditions, so passing the client explicitly is safer.

📊 **Impact:** 
Significantly reduces I/O latency and CPU overhead during PDF split processing. For multi-split PDFs, the total ingest time is expected to drop by eliminating N round-trip handshakes to Supabase storage.

🔬 **Measurement:** 
Profile the latency of the `/ingest` route when uploading a multi-page PDF (e.g., > 10 pages). Observe the reduction in connection establishment overhead in logging or tracing. The behavior has been verified with existing unit tests.

---
*PR created automatically by Jules for task [12198355291564608865](https://jules.google.com/task/12198355291564608865) started by @kourdroid*