### PR TITLE
⚡ Bolt: Optimize SequenceMatcher loop in graph.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - [Regex Pre-compilation and LRU Caching]
 **Learning:** Functions called frequently in tight loops (like `_normalize_description` and `_sanitize_for_match`) can become bottlenecks due to repeated compilation of identical regular expressions.
 **Action:** Pre-compile regular expressions using `re.compile()` at the module level. Furthermore, when a string normalization function accepts an `Any` type, wrap it with `@functools.lru_cache` but cast the argument to `str` first to avoid `TypeError: unhashable type`.
+## 2024-11-20 - [Optimizing SequenceMatcher]
+**Learning:** In Python text-processing loops, `difflib.SequenceMatcher` performance can be heavily optimized by hoisting initialization (e.g., `matcher = difflib.SequenceMatcher(None, a=static_string)`), updating the comparison string in the loop using `matcher.set_seq2(dynamic_string)`, and pre-filtering with `matcher.quick_ratio()` before invoking the expensive `matcher.ratio()` method.
+**Action:** When finding best matches in a loop with `difflib`, reuse the matcher and short-circuit with `quick_ratio()`.

--- a/src/core/graph.py
+++ b/src/core/graph.py
@@ -155,10 +155,20 @@ async def _node_fingerprint_and_lookup(state: AgentState, deps: GraphDeps) -> Co
 
     sanitized_current = _sanitize_for_match(ident.header_text)
 
+    # ⚡ Bolt: Optimize sequence matching by reusing matcher and pre-filtering with quick_ratio
+    matcher = difflib.SequenceMatcher(None, a=sanitized_current)
+
     for row in registry_rows:
         existing_text = row.get("ocr_text_cache") or ""
         sanitized_existing = _sanitize_for_match(existing_text)
-        ratio = difflib.SequenceMatcher(None, sanitized_current, sanitized_existing).ratio()
+
+        matcher.set_seq2(sanitized_existing)
+
+        # quick_ratio provides an upper bound, skip expensive ratio() if it's too low
+        if matcher.quick_ratio() <= highest_ratio:
+            continue
+
+        ratio = matcher.ratio()
         if ratio > highest_ratio:
             highest_ratio = ratio
             best_match = row


### PR DESCRIPTION
💡 **What:** The `difflib.SequenceMatcher` initialization was moved outside the loop in `_node_fingerprint_and_lookup`. The `set_seq2()` method is now used to update the comparison string on each iteration, and `matcher.quick_ratio()` is used to quickly discard poor matches.

🎯 **Why:** Creating a new `SequenceMatcher` object on every iteration recalculates expensive internal caches for the static `sanitized_current` string. The `ratio()` method is also computationally heavy (up to O(N^2)). Using `quick_ratio()` (O(N)) first allows us to skip `ratio()` entirely for poor candidates, dramatically speeding up the lookup step when dealing with large schema registries.

📊 **Impact:** Reduces time spent in the schema lookup loop significantly, especially as the number of schemas in the registry grows.

🔬 **Measurement:** Verify by running the full test suite (`pytest`) and checking the execution time of the `fingerprint_and_lookup` step for payloads against a large registry.

---
*PR created automatically by Jules for task [15746250650138011442](https://jules.google.com/task/15746250650138011442) started by @kourdroid*