### PR TITLE
⚡ Bolt: Optimize SequenceMatcher in fingerprint loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,8 @@
 ## 2024-11-20 - [Regex Pre-compilation and LRU Caching]
 **Learning:** Functions called frequently in tight loops (like `_normalize_description` and `_sanitize_for_match`) can become bottlenecks due to repeated compilation of identical regular expressions.
 **Action:** Pre-compile regular expressions using `re.compile()` at the module level. Furthermore, when a string normalization function accepts an `Any` type, wrap it with `@functools.lru_cache` but cast the argument to `str` first to avoid `TypeError: unhashable type`.
+## 2024-05-19 - SequenceMatcher Object Initialization Optimization
+
+**Learning:** `difflib.SequenceMatcher` computes and caches heuristics for the `b` sequence upon initialization. Re-instantiating `SequenceMatcher` in a tight loop is highly inefficient if one sequence is static. Using `set_seq1()` or `set_seq2()` allows you to reuse the cached computations. Furthermore, `quick_ratio()` can be used to pre-filter before calling `ratio()`, avoiding computationally expensive operations if the upper bound of the match is already lower than the current best match.
+
+**Action:** Whenever using `difflib.SequenceMatcher` inside a loop, hoist the initialization outside the loop, assign the static string to the `b` parameter, update the dynamic string using `set_seq1()`, and use `quick_ratio()` for fast-pass filtering.

--- a/src/core/graph.py
+++ b/src/core/graph.py
@@ -155,13 +155,21 @@ async def _node_fingerprint_and_lookup(state: AgentState, deps: GraphDeps) -> Co
 
     sanitized_current = _sanitize_for_match(ident.header_text)
 
+    # ⚡ Bolt Optimization:
+    # Hoist SequenceMatcher out of the loop and assign static string to `b` to cache heuristics.
+    # Pre-filter using quick_ratio() to avoid expensive ratio() calculations.
+    matcher = difflib.SequenceMatcher(None, b=sanitized_current)
+
     for row in registry_rows:
         existing_text = row.get("ocr_text_cache") or ""
         sanitized_existing = _sanitize_for_match(existing_text)
-        ratio = difflib.SequenceMatcher(None, sanitized_current, sanitized_existing).ratio()
-        if ratio > highest_ratio:
-            highest_ratio = ratio
-            best_match = row
+
+        matcher.set_seq1(sanitized_existing)
+        if matcher.quick_ratio() > highest_ratio:
+            ratio = matcher.ratio()
+            if ratio > highest_ratio:
+                highest_ratio = ratio
+                best_match = row
 
     if best_match and highest_ratio >= 0.80:
         matched_vendor = best_match.get("vendor_name") or vendor_name


### PR DESCRIPTION
💡 **What**: Hoisted the `difflib.SequenceMatcher` initialization outside the registry loop in `_node_fingerprint_and_lookup`, assigned the static `sanitized_current` string to parameter `b`, and updated the dynamic string using `matcher.set_seq1()`. Also added a fast-pass filter using `matcher.quick_ratio()` > `highest_ratio`.
🎯 **Why**: `difflib.SequenceMatcher` computes and caches character heuristics for sequence `b`. Re-instantiating the object on every iteration (O(N) object creations) is redundant and computationally expensive when one string remains static. The `ratio()` method is also an expensive algorithm, so pre-filtering with `quick_ratio()` skips unnecessary calculations when a match cannot possibly beat the highest ratio found so far.
📊 **Impact**: Reduces object instantiation overhead from O(N) to O(1) and leverages internal caching for the static comparison string. Skips the expensive `ratio()` computation for most non-matching strings, significantly speeding up the fingerprint lookup process, especially as the `document_registry` grows.
🔬 **Measurement**: The improvement can be verified through standard profiling or benchmarking the time spent in `_node_fingerprint_and_lookup` with a large number of registry entries. Tests and linter successfully pass.

---
*PR created automatically by Jules for task [4368143229199333226](https://jules.google.com/task/4368143229199333226) started by @kourdroid*