### PR TITLE
⚡ Bolt: [performance improvement] Optimize schema registry string matching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - [Regex Pre-compilation and LRU Caching]
 **Learning:** Functions called frequently in tight loops (like `_normalize_description` and `_sanitize_for_match`) can become bottlenecks due to repeated compilation of identical regular expressions.
 **Action:** Pre-compile regular expressions using `re.compile()` at the module level. Furthermore, when a string normalization function accepts an `Any` type, wrap it with `@functools.lru_cache` but cast the argument to `str` first to avoid `TypeError: unhashable type`.
+## 2024-05-30 - Optimize SequenceMatcher in loops
+**Learning:** In Python text-processing loops, `difflib.SequenceMatcher` performance can be heavily optimized by hoisting initialization and assigning the static string to `b` (e.g., `matcher = difflib.SequenceMatcher(None, b=static_string)`) because difflib caches heuristics for sequence `b`. Update the comparison string in the loop using `matcher.set_seq1(dynamic_string)`, and pre-filter with `matcher.quick_ratio()` before invoking the expensive `matcher.ratio()` method.
+**Action:** Always hoist `SequenceMatcher` and use `set_seq1()` / `quick_ratio()` when performing fuzzy string matching against multiple candidates in a loop.

--- a/src/core/graph.py
+++ b/src/core/graph.py
@@ -155,13 +155,26 @@ async def _node_fingerprint_and_lookup(state: AgentState, deps: GraphDeps) -> Co
 
     sanitized_current = _sanitize_for_match(ident.header_text)
 
+    # ⚡ Bolt Optimization:
+    # Hoist the SequenceMatcher initialization outside the loop and use `b=sanitized_current`
+    # because difflib caches heuristics for the `b` sequence. Inside the loop, update only the
+    # `a` sequence using `set_seq1()`. Furthermore, pre-filter matches with `quick_ratio()`
+    # (which is O(N)) before invoking the expensive O(N²) `ratio()` computation.
+    matcher = difflib.SequenceMatcher(None, b=sanitized_current)
+
     for row in registry_rows:
         existing_text = row.get("ocr_text_cache") or ""
         sanitized_existing = _sanitize_for_match(existing_text)
-        ratio = difflib.SequenceMatcher(None, sanitized_current, sanitized_existing).ratio()
-        if ratio > highest_ratio:
-            highest_ratio = ratio
-            best_match = row
+
+        matcher.set_seq1(sanitized_existing)
+
+        # quick_ratio() provides an upper bound; if it's not greater than our current best,
+        # there's no need to compute the exact (and expensive) ratio().
+        if matcher.quick_ratio() > highest_ratio:
+            ratio = matcher.ratio()
+            if ratio > highest_ratio:
+                highest_ratio = ratio
+                best_match = row
 
     if best_match and highest_ratio >= 0.80:
         matched_vendor = best_match.get("vendor_name") or vendor_name


### PR DESCRIPTION
💡 What: Hoists the `difflib.SequenceMatcher` initialization outside of the schema matching loop in `src/core/graph.py`. The static search string is assigned to sequence `b` (because `difflib` caches heuristics for `b`), and sequence `a` is updated per-iteration using `set_seq1()`. Furthermore, it utilizes `quick_ratio()` as a fast O(N) upper-bound check before calling the expensive O(N²) `ratio()` method.
🎯 Why: Creating a `SequenceMatcher` and calculating `ratio()` inside a loop over all database rows scales poorly. `ratio()` computes the exact matching blocks using an O(N²) algorithm, which becomes a major bottleneck as the number of schemas grows.
📊 Impact: By pre-caching heuristics and filtering non-matches in O(N) time, the overhead of the string matching loop over the registry is drastically reduced, ensuring fast lookups even as the registry grows large.
🔬 Measurement: Run the test suite `pytest` to confirm functional correctness and measure execution time when looping over a large registry of schemas.

---
*PR created automatically by Jules for task [3920601007201486039](https://jules.google.com/task/3920601007201486039) started by @kourdroid*