### PR TITLE
⚡ Bolt: [performance improvement] Shared AsyncClient for SupabaseStorage uploads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - [Regex Pre-compilation and LRU Caching]
 **Learning:** Functions called frequently in tight loops (like `_normalize_description` and `_sanitize_for_match`) can become bottlenecks due to repeated compilation of identical regular expressions.
 **Action:** Pre-compile regular expressions using `re.compile()` at the module level. Furthermore, when a string normalization function accepts an `Any` type, wrap it with `@functools.lru_cache` but cast the argument to `str` first to avoid `TypeError: unhashable type`.
+## 2024-11-20 - [HTTP Connection Pooling for Concurrent Uploads]
+**Learning:** Using `asyncio.gather` for concurrent I/O isn't fully optimized if the underlying HTTP client (like `httpx.AsyncClient`) is instantiated inside the sub-task. This causes repeated TCP/TLS handshakes, negating some concurrency benefits.
+**Action:** When performing concurrent HTTP requests (e.g., uploading many files), instantiate a shared `httpx.AsyncClient` outside the loop/task generation using an `async with` block, and pass the client into the concurrent sub-tasks to take advantage of HTTP connection pooling.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -4,14 +4,14 @@ import asyncio
 import logging
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
+import httpx
 import aiofiles
 import asyncpg
 import tempfile
 import redis.asyncio as redis
 from fastapi import APIRouter, HTTPException, Query, UploadFile
-from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from src.config import get_settings
@@ -79,7 +79,7 @@ async def ingest(file: UploadFile) -> IngestResponse:
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
             target_path = Path(tmpdir) / f"{job_id}.pdf"
-            
+
             content = await file.read()
             if not content:
                 logger.error("step=ingest status=failed reason=empty_file")
@@ -99,31 +99,35 @@ async def ingest(file: UploadFile) -> IngestResponse:
             try:
                 upload_tasks = []
                 sp_job_ids = []
-                for split_index, sp in enumerate(split_paths, start=1):
-                    sp_job_id = str(uuid.uuid4())
-                    sp_job_ids.append(sp_job_id)
-                    split_name = Path(sp).name
-                    logger.info(
-                        "step=ingest split_process status=start split_index=%s total_splits=%s split_file=%s",
-                        split_index,
-                        len(split_paths),
-                        split_name,
-                    )
-                    file_bytes = Path(sp).read_bytes()
-                    upload_tasks.append(storage.upload(f"{sp_job_id}.pdf", file_bytes))
 
-                try:
-                    # ⚡ Bolt Optimization:
-                    # Execute all storage uploads concurrently using asyncio.gather
-                    # This replaces the N+1 sequential await calls inside the loop,
-                    # reducing total upload time from O(N) to roughly O(1) for split PDFs.
-                    public_urls = await asyncio.gather(*upload_tasks)
-                except Exception as exc:
-                    logger.exception(
-                        "step=ingest split_process status=failed phase=upload total_splits=%s",
-                        len(split_paths),
-                    )
-                    raise SplitEnqueueError(phase="upload", split_file="multiple_splits", original_error=exc) from exc
+                async with httpx.AsyncClient(timeout=storage.timeout) as client:
+                    for split_index, sp in enumerate(split_paths, start=1):
+                        sp_job_id = str(uuid.uuid4())
+                        sp_job_ids.append(sp_job_id)
+                        split_name = Path(sp).name
+                        logger.info(
+                            "step=ingest split_process status=start split_index=%s total_splits=%s split_file=%s",
+                            split_index,
+                            len(split_paths),
+                            split_name,
+                        )
+                        file_bytes = Path(sp).read_bytes()
+                        upload_tasks.append(storage.upload(f"{sp_job_id}.pdf", file_bytes, client=client))
+
+                    try:
+                        # ⚡ Bolt Optimization:
+                        # Execute all storage uploads concurrently using asyncio.gather
+                        # We also pass a shared httpx.AsyncClient to avoid repeatedly
+                        # creating connection pools and performing TCP/TLS handshakes.
+                        public_urls = await asyncio.gather(*upload_tasks)
+                    except Exception as exc:
+                        logger.exception(
+                            "step=ingest split_process status=failed phase=upload total_splits=%s",
+                            len(split_paths),
+                        )
+                        raise SplitEnqueueError(
+                            phase="upload", split_file="multiple_splits", original_error=exc
+                        ) from exc
 
                 for sp_job_id, public_url in zip(sp_job_ids, public_urls):
                     jobs_to_create.append(
@@ -143,7 +147,9 @@ async def ingest(file: UploadFile) -> IngestResponse:
                             "step=ingest split_process status=failed phase=create_jobs_bulk total_splits=%s",
                             len(split_paths),
                         )
-                        raise SplitEnqueueError(phase="create_jobs_bulk", split_file="all_splits", original_error=exc) from exc
+                        raise SplitEnqueueError(
+                            phase="create_jobs_bulk", split_file="all_splits", original_error=exc
+                        ) from exc
 
                     try:
                         await queue.enqueue_jobs_bulk(jobs_to_create)
@@ -152,7 +158,9 @@ async def ingest(file: UploadFile) -> IngestResponse:
                             "step=ingest split_process status=failed phase=enqueue_jobs_bulk total_splits=%s",
                             len(split_paths),
                         )
-                        raise SplitEnqueueError(phase="enqueue_jobs_bulk", split_file="all_splits", original_error=exc) from exc
+                        raise SplitEnqueueError(
+                            phase="enqueue_jobs_bulk", split_file="all_splits", original_error=exc
+                        ) from exc
             except Exception as exc:
                 logger.exception("step=ingest enqueue_failed count=%s", len(job_ids))
                 for jid in job_ids:

--- a/src/infrastructure/supabase_storage.py
+++ b/src/infrastructure/supabase_storage.py
@@ -21,27 +21,42 @@ class SupabaseStorage:
             "apikey": self.service_role_key,
         }
 
-    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf") -> str:
+    async def upload(
+        self, path: str, data: bytes, content_type: str = "application/pdf", client: httpx.AsyncClient | None = None
+    ) -> str:
         """Upload file, return public URL."""
         url = f"{self.supabase_url}/storage/v1/object/{self.BUCKET}/{path}"
-        
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
+
+        if client:
             resp = await client.post(
                 url,
                 content=data,
                 headers={**self.headers, "Content-Type": content_type},
             )
             resp.raise_for_status()
-            
+        else:
+            async with httpx.AsyncClient(timeout=self.timeout) as new_client:
+                resp = await new_client.post(
+                    url,
+                    content=data,
+                    headers={**self.headers, "Content-Type": content_type},
+                )
+                resp.raise_for_status()
+
         return self.get_public_url(path)
 
-    async def download(self, path: str) -> bytes:
+    async def download(self, path: str, client: httpx.AsyncClient | None = None) -> bytes:
         """Download file bytes."""
         url = f"{self.supabase_url}/storage/v1/object/{self.BUCKET}/{path}"
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
+        if client:
             resp = await client.get(url, headers=self.headers)
             resp.raise_for_status()
             return resp.content
+        else:
+            async with httpx.AsyncClient(timeout=self.timeout) as new_client:
+                resp = await new_client.get(url, headers=self.headers)
+                resp.raise_for_status()
+                return resp.content
 
     def get_public_url(self, path: str) -> str:
         """Construct the public URL without an API call."""

--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -36,9 +36,9 @@ class DummyJobsRepo:
 
 class DummyStorage:
     def __init__(self, *_args, **_kwargs) -> None:
-        pass
+        self.timeout = 60.0
 
-    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf") -> str:
+    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf", client=None) -> str:
         return "http://example.com/file.pdf"
 
 

--- a/tests/test_api_ingest_split_failure.py
+++ b/tests/test_api_ingest_split_failure.py
@@ -32,9 +32,10 @@ class DummyJobsRepo:
 
 class FailingStorage:
     def __init__(self, *_args, **_kwargs) -> None:
+        self.timeout = 60.0
         return None
 
-    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf") -> str:
+    async def upload(self, path: str, data: bytes, content_type: str = "application/pdf", client=None) -> str:
         raise TimeoutError("storage upload timed out")
 
 


### PR DESCRIPTION
💡 **What**: Added an optional `client: httpx.AsyncClient | None = None` parameter to `SupabaseStorage.upload` and `download`. In `src/api/routes.py`, we now instantiate a shared `httpx.AsyncClient` outside the upload loop and pass it to all concurrent tasks created for `asyncio.gather`.
🎯 **Why**: Previously, each call to `storage.upload` created its own `httpx.AsyncClient`. Even though the calls were run concurrently using `asyncio.gather`, they each established a separate TCP connection and performed a separate TLS handshake with Supabase. Reusing a single client allows HTTP connection pooling and multiplexing, significantly reducing latency and overhead.
📊 **Impact**: Reduces total ingestion latency for split PDFs by eliminating N-1 TLS handshakes and TCP connection establishments. This is especially impactful for large invoices that split into many individual pages.
🔬 **Measurement**: Ingestion endpoint response times for multi-page PDFs should decrease. This can be verified by observing network logs or tracing the `/ingest` endpoint latency on large PDF files.

---
*PR created automatically by Jules for task [12994270773963837123](https://jules.google.com/task/12994270773963837123) started by @kourdroid*