### PR TITLE
Add AGPL and commercial licensing

### DIFF
--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -1,0 +1,28 @@
+# Commercial Licensing
+
+OCRAgent / Ironclad IDP is available under two licensing paths.
+
+## Open-source licence
+
+The repository is offered under the GNU Affero General Public License, version 3 only (`AGPL-3.0-only`). The AGPL licence applies unless you have received a separate written commercial licence from the copyright holder.
+
+The AGPL is suitable when you are willing to comply with its conditions, including the source-code obligations that may apply when a modified version is made available to users over a computer network.
+
+## Commercial licence
+
+A separate commercial licence may be available for organisations that need terms not provided by the AGPL, including situations such as:
+
+- incorporating OCRAgent into proprietary software;
+- distributing a modified version without licensing the combined work under the AGPL;
+- operating a modified hosted service without the AGPL network-source obligations;
+- receiving negotiated warranties, support, indemnities, service levels, or deployment rights.
+
+Commercial terms are granted only through a separate written agreement signed by the copyright holder. This file is a notice and does not itself grant a commercial licence.
+
+## Contact
+
+Commercial licensing enquiries should be directed to El Mehdi Kourchal through the contact information published on the official project repository or project website.
+
+## Copyright
+
+Copyright (C) 2026 El Mehdi Kourchal. All rights reserved except as expressly granted under the applicable licence.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+OCRAgent / Ironclad IDP
+Copyright (C) 2026 El Mehdi Kourchal
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3 only.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+SPDX-License-Identifier: AGPL-3.0-only
+
+The complete, unmodified GNU Affero General Public License version 3 text is available from the Free Software Foundation:
+https://www.gnu.org/licenses/agpl-3.0.txt
+
+A separate commercial licence may be available from the copyright holder. See COMMERCIAL-LICENSE.md.


### PR DESCRIPTION
## Summary

- add an `AGPL-3.0-only` licence notice for OCRAgent / Ironclad IDP
- identify El Mehdi Kourchal as the 2026 copyright holder
- add a separate commercial-licensing notice for proprietary, embedded, and hosted use cases

## Important note

The `LICENSE` file contains the applicable AGPL notice, SPDX identifier, warranty disclaimer, and an official link to the complete unmodified AGPL v3 text. The full 35 KB licence body is not vendored in this PR because the connector used to prepare the change could not transfer the reference file verbatim. Vendoring the official full text can be a follow-up before merging if desired.

No application source code or runtime configuration was changed.