### PR TITLE
⚡ Bolt: [performance improvement] Add database indexes for processing_jobs queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2024-11-20 - [HTTP Connection Pooling for Concurrent Uploads]
 **Learning:** Using `asyncio.gather` for concurrent I/O isn't fully optimized if the underlying HTTP client (like `httpx.AsyncClient`) is instantiated inside the sub-task. This causes repeated TCP/TLS handshakes, negating some concurrency benefits.
 **Action:** When performing concurrent HTTP requests (e.g., uploading many files), instantiate a shared `httpx.AsyncClient` outside the loop/task generation using an `async with` block, and pass the client into the concurrent sub-tasks to take advantage of HTTP connection pooling.
+## 2024-11-20 - [Database Query Performance with Missing Indexes]
+**Learning:** `list_jobs` endpoints in Supabase repositories can experience O(N) or O(N log N) scaling issues when querying and sorting by `created_at DESC` or `status` without appropriate backing indexes in PostgreSQL.
+**Action:** Created concurrent B-Tree indexes on `processing_jobs (status, created_at DESC)` and `processing_jobs (created_at DESC)` to allow PostgreSQL to do backwards index scans and turn these into O(LIMIT) queries.

--- a/sql/004_add_jobs_indexes.sql
+++ b/sql/004_add_jobs_indexes.sql
@@ -1,0 +1,9 @@
+-- Migration: Add indexes to processing_jobs table for efficient querying
+
+-- 1. Index for list_jobs queries filtering by status and ordering by created_at DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_processing_jobs_status_created_at
+ON processing_jobs (status, created_at DESC);
+
+-- 2. Index for list_jobs queries ordering by created_at DESC (without status filter)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_processing_jobs_created_at
+ON processing_jobs (created_at DESC);


### PR DESCRIPTION
💡 What: Added two database indexes `(status, created_at DESC)` and `(created_at DESC)` to the `processing_jobs` table via a new SQL script.
🎯 Why: The `/jobs` endpoint queries the database by status and orders by `created_at DESC` with a limit and offset. Without indexes, PostgreSQL has to do a sequential scan and in-memory sort, which scales O(N log N).
📊 Impact: Turns O(N log N) sorting operations into O(LIMIT) backwards B-Tree index scans. Measurable reduction in database CPU load and API latency for the `/jobs` endpoint, particularly at scale.
🔬 Measurement: Can be verified using `EXPLAIN ANALYZE` on the `SELECT * FROM processing_jobs ORDER BY created_at DESC LIMIT 50` query before and after the indexes are applied.

---
*PR created automatically by Jules for task [16887026419785533012](https://jules.google.com/task/16887026419785533012) started by @kourdroid*