### PR TITLE
⚡ Bolt: [performance improvement] Use database connection pool in health endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2024-11-20 - [HTTP Connection Pooling for Concurrent Uploads]
 **Learning:** Using `asyncio.gather` for concurrent I/O isn't fully optimized if the underlying HTTP client (like `httpx.AsyncClient`) is instantiated inside the sub-task. This causes repeated TCP/TLS handshakes, negating some concurrency benefits.
 **Action:** When performing concurrent HTTP requests (e.g., uploading many files), instantiate a shared `httpx.AsyncClient` outside the loop/task generation using an `async with` block, and pass the client into the concurrent sub-tasks to take advantage of HTTP connection pooling.
+
+## 2024-11-20 - [Database Connection Pooling in Health Endpoints]
+**Learning:** High-frequency endpoints like `/health` shouldn't create direct database connections (e.g., `asyncpg.connect()`) as it introduces an expensive TCP/TLS handshake overhead.
+**Action:** Use a shared connection pool (like `get_connection_pool`) even for simple heartbeat queries to avoid unnecessary database bottlenecks.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository, get_connection_pool
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -317,13 +317,11 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
                 return {"ok": True}
-            finally:
-                await conn.close()
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
💡 What: Replaced direct `asyncpg.connect()` with `get_connection_pool()` in the `/health` endpoint.
🎯 Why: Creating a fresh direct database connection on every request introduces a slow, expensive TCP/TLS handshake. High-frequency endpoints like `/health` should always use connection pooling.
📊 Impact: Significantly reduces latency on `/health` calls by reusing existing TCP/TLS connections from the global pool, eliminating connection setup overhead.
🔬 Measurement: Endpoint latency metrics and database connection count stability under load.

---
*PR created automatically by Jules for task [1700001809806081469](https://jules.google.com/task/1700001809806081469) started by @kourdroid*