### PR TITLE
⚡ Bolt: [performance improvement] Use connection pool for /health endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2024-11-20 - [HTTP Connection Pooling for Concurrent Uploads]
 **Learning:** Using `asyncio.gather` for concurrent I/O isn't fully optimized if the underlying HTTP client (like `httpx.AsyncClient`) is instantiated inside the sub-task. This causes repeated TCP/TLS handshakes, negating some concurrency benefits.
 **Action:** When performing concurrent HTTP requests (e.g., uploading many files), instantiate a shared `httpx.AsyncClient` outside the loop/task generation using an `async with` block, and pass the client into the concurrent sub-tasks to take advantage of HTTP connection pooling.
+## 2024-11-20 - [Database Connection Pool Reuse in API Endpoints]
+**Learning:** Using `asyncpg.connect()` on every API request (e.g. `/health`) creates a new TCP/TLS connection directly to the database on every call, bypassing connection pooling and causing N+1 connection overhead for simple health checks.
+**Action:** When working in high-frequency FastAPI routes, import `get_connection_pool` (from `src.infrastructure.supabase_repos`) to retrieve a shared connection pool, and acquire a connection via `async with pool.acquire() as conn:` to avoid expensive handshakes on every request.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from src.config import get_settings
 from src.core.pdf_splitter import split_pdf
 from src.infrastructure.redis_queue import RedisQueue
-from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository
+from src.infrastructure.supabase_repos import SupabaseJobsRepository, SupabaseRegistryRepository, get_connection_pool
 from src.infrastructure.supabase_storage import SupabaseStorage
 
 router = APIRouter()
@@ -317,13 +317,18 @@ async def health() -> dict:
 
     async def _check_tables() -> dict[str, object]:
         try:
-            conn = await asyncpg.connect(settings.database_url, statement_cache_size=0)
-            try:
+            # ⚡ Bolt Optimization:
+            # We reuse the shared connection pool instead of creating a new
+            # connection via asyncpg.connect() on every health check request.
+            # This prevents expensive TCP/TLS handshakes and eliminates an N+1
+            # connection overhead.
+            # Expected impact: Significantly reduces latency on /health endpoint calls
+            # Measurement: Benchmarking /health should show reduced p99 latencies.
+            pool = await get_connection_pool(settings.database_url)
+            async with pool.acquire() as conn:
                 await conn.execute("SELECT job_id FROM processing_jobs LIMIT 1")
                 await conn.execute("SELECT id FROM document_registry LIMIT 1")
                 return {"ok": True}
-            finally:
-                await conn.close()
         except asyncpg.PostgresError as exc:
             code = getattr(exc, "sqlstate", "")
             return {"ok": False, "error": str(exc), "code": code}


### PR DESCRIPTION
💡 **What:** 
Updated the database health check in `src/api/routes.py` to reuse the application's shared `asyncpg` connection pool via `get_connection_pool` rather than establishing a new, direct TCP/TLS database connection with `asyncpg.connect()` on every request.

🎯 **Why:** 
`/health` endpoints are typically polled aggressively by load balancers and orchestrators. Opening a new database connection on every check is extremely expensive (TCP handshake, TLS negotiation, authentication) and bypasses the connection pooling layer, which can cause connection exhaustion or unnecessary latency bottlenecks under load.

📊 **Impact:** 
Significantly reduces latency (especially p99) and database load on every health check request, eliminating the N+1 connection overhead.

🔬 **Measurement:** 
Benchmarking the `/health` endpoint before and after under sustained polling (e.g., using `hey` or `wrk`) should demonstrate consistently lower response times and reduced connection thrashing on the Postgres server.

---
*PR created automatically by Jules for task [17055683758973376856](https://jules.google.com/task/17055683758973376856) started by @kourdroid*