### PR TITLE
⚡ Bolt: Chunked file reading to prevent memory spikes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,9 @@
 ## 2024-11-20 - [HTTP Connection Pooling for Concurrent Uploads]
 **Learning:** Using `asyncio.gather` for concurrent I/O isn't fully optimized if the underlying HTTP client (like `httpx.AsyncClient`) is instantiated inside the sub-task. This causes repeated TCP/TLS handshakes, negating some concurrency benefits.
 **Action:** When performing concurrent HTTP requests (e.g., uploading many files), instantiate a shared `httpx.AsyncClient` outside the loop/task generation using an `async with` block, and pass the client into the concurrent sub-tasks to take advantage of HTTP connection pooling.
+## 2024-11-20 - [Chunked File Reads for Uploads]
+**Learning:** In backend endpoints processing file uploads (like PDF ingestion),  loads the entire file into memory at once, causing massive memory spikes and potential OOM errors for large documents.
+**Action:** Always process large file uploads using chunked reads (e.g. `await file.read(1024 * 1024)`) inside a loop and write to a destination stream piece by piece to maintain a constant memory footprint.
+## 2024-11-20 - [Chunked File Reads for Uploads]
+**Learning:** In backend endpoints processing file uploads (like PDF ingestion), `await file.read()` loads the entire file into memory at once, causing massive memory spikes and potential OOM errors for large documents.
+**Action:** Always process large file uploads using chunked reads (e.g. `await file.read(1024 * 1024)`) inside a loop and write to a destination stream piece by piece to maintain a constant memory footprint.

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -80,14 +80,17 @@ async def ingest(file: UploadFile) -> IngestResponse:
         with tempfile.TemporaryDirectory() as tmpdir:
             target_path = Path(tmpdir) / f"{job_id}.pdf"
 
-            content = await file.read()
-            if not content:
+            file_size = 0
+            async with aiofiles.open(target_path, "wb") as f:
+                while chunk := await file.read(1024 * 1024):
+                    file_size += len(chunk)
+                    await f.write(chunk)
+
+            if file_size == 0:
                 logger.error("step=ingest status=failed reason=empty_file")
                 raise HTTPException(status_code=400, detail="Uploaded file is empty")
 
-            logger.info("step=ingest action=save_tmp file_size=%s", len(content))
-            async with aiofiles.open(target_path, "wb") as f:
-                await f.write(content)
+            logger.info("step=ingest action=save_tmp file_size=%s", file_size)
 
             split_paths = split_pdf(target_path, output_dir=Path(tmpdir))
 


### PR DESCRIPTION
💡 **What:** 
Updated the `/ingest` endpoint in `src/api/routes.py` to process uploaded PDF files using 1MB chunked reads (`await file.read(1024 * 1024)`) instead of loading the entire file into memory at once (`await file.read()`).

🎯 **Why:** 
Loading large PDF invoices entirely into memory with a single `read()` call creates massive memory spikes per request. Under high concurrency or when handling exceptionally large documents, this can lead to Out-Of-Memory (OOM) errors and application crashes.

📊 **Impact:** 
Maintains a constant ~1MB memory footprint per active upload request, regardless of the uploaded file's total size, drastically improving the backend's memory efficiency and resilience under load.

🔬 **Measurement:** 
Submit a large PDF (e.g., >50MB) to the `/ingest` endpoint and monitor the memory usage of the backend process using standard profiling tools. The memory footprint will remain flat during the upload, compared to a linear spike equal to the file size previously.

---
*PR created automatically by Jules for task [11101340795098429476](https://jules.google.com/task/11101340795098429476) started by @kourdroid*