### PR TITLE
⚡ Bolt: Memoize _sanitize_for_match to avoid redundant regex parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2024-11-20 - [HTTP Connection Pooling for Concurrent Uploads]
 **Learning:** Using `asyncio.gather` for concurrent I/O isn't fully optimized if the underlying HTTP client (like `httpx.AsyncClient`) is instantiated inside the sub-task. This causes repeated TCP/TLS handshakes, negating some concurrency benefits.
 **Action:** When performing concurrent HTTP requests (e.g., uploading many files), instantiate a shared `httpx.AsyncClient` outside the loop/task generation using an `async with` block, and pass the client into the concurrent sub-tasks to take advantage of HTTP connection pooling.
+## 2025-02-05 - Optimize _sanitize_for_match in _node_fingerprint_and_lookup
+**Learning:** Found that `_sanitize_for_match` uses regex substitution heavily and is called for every existing `ocr_text_cache` in `registry_rows` on each document ingestion. However, these cached string values are static schema components pulled directly from the database. Re-evaluating the regex substitutions on identical text thousands of times per day is highly inefficient.
+**Action:** Always ensure that pure functions operating on static reference data inside busy loops or traversal operations are aggressively memoized (`@functools.lru_cache`). I've wrapped `_sanitize_for_match` with `lru_cache(maxsize=1024)`.

--- a/src/core/graph.py
+++ b/src/core/graph.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import difflib
+import functools
 import logging
 import re
 from dataclasses import dataclass
@@ -22,6 +23,10 @@ _SANITIZE_PUNC_RE = re.compile(r'[\/:\-\.]+')
 _SANITIZE_DIGIT_RE = re.compile(r'\d+')
 
 
+# ⚡ Bolt Optimization:
+# Memoize the deterministic regex operations to avoid re-evaluating the same
+# cache strings (like those from the registry loop) on every invocation.
+@functools.lru_cache(maxsize=1024)
 def _sanitize_for_match(text: str) -> str:
     if not text:
         return ""


### PR DESCRIPTION
💡 **What:** Added `@functools.lru_cache(maxsize=1024)` to `_sanitize_for_match` in `src/core/graph.py` to memoize deterministic regex substitutions on static string operations.

🎯 **Why:** `_sanitize_for_match` is called repeatedly inside `_node_fingerprint_and_lookup` where it loops over `registry_rows`. Since the `ocr_text_cache` definitions it processes are statically loaded from the database schemas, it performs the exact same regex substitutions repeatedly for every processed invoice. Memoizing this function prevents wasting CPU cycles recomputing identical strings.

📊 **Impact:** Substantially reduces total CPU time spent resolving vendor schemas when `registry_rows` count scales up. Converts worst-case `O(M * L)` regex substitution complexity (where M is row count and L is string length) into an O(1) hash map lookup after initial evaluation.

🔬 **Measurement:** Can be verified by measuring CPU profiling during `_node_fingerprint_and_lookup` with multiple identical registry configurations; execution time scaling will be flattened.

---
*PR created automatically by Jules for task [7950286067600892057](https://jules.google.com/task/7950286067600892057) started by @kourdroid*