### PR TITLE
⚡ Bolt: [performance improvement] Cache `_sanitize_for_match`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2024-11-20 - [HTTP Connection Pooling for Concurrent Uploads]
 **Learning:** Using `asyncio.gather` for concurrent I/O isn't fully optimized if the underlying HTTP client (like `httpx.AsyncClient`) is instantiated inside the sub-task. This causes repeated TCP/TLS handshakes, negating some concurrency benefits.
 **Action:** When performing concurrent HTTP requests (e.g., uploading many files), instantiate a shared `httpx.AsyncClient` outside the loop/task generation using an `async with` block, and pass the client into the concurrent sub-tasks to take advantage of HTTP connection pooling.
+## 2024-11-20 - [Regex Pre-compilation and LRU Caching]
+**Learning:** Functions called frequently in tight loops (like `_normalize_description` and `_sanitize_for_match`) can become bottlenecks due to repeated compilation of identical regular expressions and repeated operations.
+**Action:** Pre-compile regular expressions using `re.compile()` at the module level. Furthermore, when a string normalization function is called multiple times on duplicate strings, wrap it with `@functools.lru_cache` but cast the argument to a hashable type if needed to avoid `TypeError: unhashable type`.

--- a/src/core/graph.py
+++ b/src/core/graph.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import difflib
+import functools
 import logging
 import re
 from dataclasses import dataclass
@@ -22,6 +23,12 @@ _SANITIZE_PUNC_RE = re.compile(r'[\/:\-\.]+')
 _SANITIZE_DIGIT_RE = re.compile(r'\d+')
 
 
+# ⚡ Bolt Optimization:
+# Adding an LRU cache prevents redundant regular expression evaluations and string
+# operations for duplicate inputs during frequent matching checks.
+# Impact: Improves CPU utilization and speeds up matching latency by avoiding O(N)
+# duplicate sanitization cycles on repeated headers/terms.
+@functools.lru_cache(maxsize=1024)
 def _sanitize_for_match(text: str) -> str:
     if not text:
         return ""


### PR DESCRIPTION
💡 **What**: Added `@functools.lru_cache(maxsize=1024)` to the `_sanitize_for_match` pure string processing function in `src/core/graph.py` and included documentation explaining it.

🎯 **Why**: The `_sanitize_for_match` function is called inside a loop over all cached schemas (`registry_rows`) during vendor discovery (`_node_fingerprint_and_lookup`). Duplicate strings like identical headers are very common during this process. Caching prevents redundant string allocations and regular expression substitutions.

📊 **Impact**: Improves CPU utilization and speeds up matching latency by avoiding O(N) duplicate sanitization cycles on repeated terms.

🔬 **Measurement**: Verified by ensuring the pytest test suite completes without regressions.

---
*PR created automatically by Jules for task [16715758580053697525](https://jules.google.com/task/16715758580053697525) started by @kourdroid*