### PR TITLE
⚡ Bolt: Refactor _load_document to use async I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2024-11-20 - [HTTP Connection Pooling for Concurrent Uploads]
 **Learning:** Using `asyncio.gather` for concurrent I/O isn't fully optimized if the underlying HTTP client (like `httpx.AsyncClient`) is instantiated inside the sub-task. This causes repeated TCP/TLS handshakes, negating some concurrency benefits.
 **Action:** When performing concurrent HTTP requests (e.g., uploading many files), instantiate a shared `httpx.AsyncClient` outside the loop/task generation using an `async with` block, and pass the client into the concurrent sub-tasks to take advantage of HTTP connection pooling.
+
+## 2024-05-18 - [Async Mocks for LangGraph Nodes]
+**Learning:** When mocking asynchronous I/O functions (like `_load_document`) within LangGraph node tests, the mock function *must* be an `async def`. A synchronous lambda returning a dummy object (e.g., `lambda _p: object()`) will cause an `await` failure (`TypeError: object object can't be used in 'await' expression`) when the LangGraph runner attempts to execute the node.
+**Action:** When updating a synchronous function to be asynchronous, remember to update any unit tests that mock it using `monkeypatch.setattr` to ensure the mock is an asynchronous function or returns an awaitable.

--- a/src/core/graph.py
+++ b/src/core/graph.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Optional, Protocol
 
+import aiofiles
 import httpx
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import Command
@@ -117,14 +118,19 @@ class GraphDeps:
     webhook: WebhookClient
 
 
-def _load_document(file_path: str) -> Any:
+# ⚡ Bolt Optimization:
+# Refactored _load_document to use async I/O (httpx.AsyncClient and aiofiles)
+# This prevents blocking the main event loop during document fetching,
+# significantly improving concurrent performance in high-throughput scenarios.
+async def _load_document(file_path: str) -> Any:
     if file_path.startswith("http://") or file_path.startswith("https://"):
-        resp = httpx.get(file_path)
-        resp.raise_for_status()
-        pdf_bytes = resp.content
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(file_path)
+            resp.raise_for_status()
+            pdf_bytes = resp.content
     else:
-        with open(file_path, "rb") as f:
-            pdf_bytes = f.read()
+        async with aiofiles.open(file_path, "rb") as f:
+            pdf_bytes = await f.read()
 
     class PDFPart:
         mime_type = "application/pdf"
@@ -142,7 +148,7 @@ async def _node_fingerprint_and_lookup(state: AgentState, deps: GraphDeps) -> Co
     logger.info("job=%s step=fingerprint_and_lookup status=start file=%s", job_id, file_path)
     await deps.jobs.mark_processing(job_id, None)
 
-    image = _load_document(file_path)
+    image = await _load_document(file_path)
     ident: VendorIdentification = await identify_vendor(image)
 
     fingerprint_hash = compute_fingerprint(ident.header_text)
@@ -210,7 +216,7 @@ async def _node_discovery_agent(state: AgentState) -> Command[str]:
         return Command(update={"error": "Missing file_path"}, goto=END)
 
     logger.info("job=%s step=discovery_agent status=start", job_id)
-    image = _load_document(file_path)
+    image = await _load_document(file_path)
     schema = await discover_schema(image)
     logger.info("job=%s step=discovery_agent status=done vendor=%s version=%s", job_id, schema.vendor_name, schema.version)
     return Command(update={"proposed_schema": schema.model_dump()}, goto="human_hold")
@@ -244,7 +250,7 @@ async def _node_extract(state: AgentState, deps: GraphDeps) -> Command[str]:
         return Command(update={"error": "Missing job_id, file_path, or current_schema"}, goto=END)
 
     logger.info("job=%s step=extract status=start vendor=%s", job_id, vendor_name)
-    image = _load_document(file_path)
+    image = await _load_document(file_path)
     schema = RegistrySchema.model_validate(schema_dict)
     extracted = await extract_with_schema(image, schema)
 

--- a/tests/test_langgraph_async_nodes.py
+++ b/tests/test_langgraph_async_nodes.py
@@ -49,7 +49,9 @@ async def test_graph_nodes_are_awaited(monkeypatch) -> None:
     async def fake_discover_schema(_image):
         return RegistrySchema(vendor_name="DHL_Express", fields=[], version=1)
 
-    monkeypatch.setattr("src.core.graph._load_document", lambda _p: object())
+    async def fake_load_document(_p):
+        return object()
+    monkeypatch.setattr("src.core.graph._load_document", fake_load_document)
     monkeypatch.setattr("src.core.graph.identify_vendor", fake_identify_vendor)
     monkeypatch.setattr("src.core.graph.discover_schema", fake_discover_schema)
 


### PR DESCRIPTION
💡 **What:** 
Refactored `_load_document` in `src/core/graph.py` to be an `async def`. Replaced synchronous network requests (`httpx.get`) with `httpx.AsyncClient().get()` and synchronous file reads (`open(..., "rb").read()`) with `aiofiles.open(..., "rb").read()`.

🎯 **Why:** 
The application relies heavily on `_load_document` within its LangGraph nodes (`_node_fingerprint_and_lookup`, `_node_discovery_agent`, `_node_extract`). Before this change, these synchronous I/O operations blocked the main event loop, significantly degrading concurrent performance and throughput.

📊 **Impact:** 
Massively improves concurrent performance by unblocking the event loop. In high-throughput scenarios, the application will no longer pause all other async tasks while waiting for file downloads or disk reads.

🔬 **Measurement:** 
Run the application under load and monitor event loop latency (e.g., using `asyncio` debug mode). You should observe zero event loop stalls during the file fetching phase compared to the previous synchronous implementation. Also, the `test_graph_nodes_are_awaited` test passes.

---
*PR created automatically by Jules for task [3155205736817802531](https://jules.google.com/task/3155205736817802531) started by @kourdroid*